### PR TITLE
Fixes the dependency name in dev profile for using the tap reporter to test its...

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,6 @@
 
   :dependencies [[org.clojure/clojure "1.6.0"]]
   :profiles {:dev {:dependencies [[speclj "3.2.0"]
-                                  [speclj-tap-runner "0.1.0-SNAPSHOT"]]}}
+                                  [speclj-tap-reporter "0.0.1-SNAPSHOT"]]}}
   :plugins [[speclj "3.2.0"]]
   :test-paths ["spec"])


### PR DESCRIPTION
dev dependency for the tap reporter for self testing was incorrect (speclj-tap-runner and with wrong version number)

This changes the dependency to [speclj-tap-reporter "0.0.1-SNAPSHOT"]
